### PR TITLE
Fix ADC temperature reading

### DIFF
--- a/Core/Inc/sensors/sensor_temperature.h
+++ b/Core/Inc/sensors/sensor_temperature.h
@@ -22,6 +22,7 @@ typedef enum {
 void sensor_temperature_init(void);
 void sensor_temperature_start(void);
 void sensor_temperature_stop(void);
+void sensor_temperature_tick_1s(void);
 
 bool sensor_temperature_has_started(void);
 bool sensor_temperature_is_measurement_ready(void);

--- a/Core/Src/fsm/fsm_main.c
+++ b/Core/Src/fsm/fsm_main.c
@@ -32,8 +32,9 @@ static void performRestart(void) {
 }
 
 static bool isInitSuccess(void) {
-  return true;
-  return sensor_temperature_has_started() && sensor_heartrate_has_started() && sensor_gps_has_started();
+  return sensor_temperature_has_started();
+  // TODO: Implement other sensors check
+  // return sensor_temperature_has_started() && sensor_heartrate_has_started() && sensor_gps_has_started();
 }
 
 static bool isLinkEstablished(void) {
@@ -63,9 +64,15 @@ static bool hasBackupChannelFailed = false;
 
 void FSM_Main_init(void) {
   currentState = INIT;
+  // Initialize sensors
   sensor_temperature_init();
   sensor_heartrate_init();
   sensor_gps_init();
+
+  // But stop such sensors until they are needed
+  sensor_temperature_stop();
+  sensor_heartrate_stop();
+  sensor_gps_stop();
 
   initTimer = INIT_TIMEOUT;
 }
@@ -137,4 +144,5 @@ void FSM_Main_tick_1s(void) {
       FSM_Transmit_tick_1s();
     }
   }
+  sensor_temperature_tick_1s();
 }

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -44,8 +44,6 @@ int main(void) {
 
     // Peripherals initialization
     GPIO_Init();
-    GPIO_temperature_power_init();
-    ADC_Init();
     DMA_Init();
     USART2_Init();
     MX_I2C1_Init();
@@ -54,20 +52,16 @@ int main(void) {
 
     // Run tests
     adc_test();
-     gps_test();
-     adc_test();
-     gps_test();
-
-     hr_test();
+    gps_test();
+    adc_test();
+    gps_test();
+    hr_test();
 
     //testing_leds_init();
 
     // System start
     FSM_Main_init();
     HAL_TIM_Base_Start_IT(&htim2);
-//    testing_led1_on();
-//    testing_led2_on();
-    // gpio_temperature_power_start();
     while (1) {
     	 FSM_Main_handle();
     }


### PR DESCRIPTION
Problem was in initialization. We need to leave a time window between:
- powering up the MCP, and
- reading voltage with the ADC

Since we want to power the MCP on and off, periodically, during the execution, we need to create the time window between both events, we do that using a timer